### PR TITLE
Add feed

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/controller/UserFeedController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/UserFeedController.java
@@ -1,0 +1,23 @@
+package ru.yandex.practicum.filmorate.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ru.yandex.practicum.filmorate.entity.Event;
+import ru.yandex.practicum.filmorate.service.EventService;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserFeedController {
+    private final EventService eventService;
+
+    @GetMapping("/{userId}/feed")
+    public List<Event> getUserFeed(@PathVariable Long userId) {
+        return eventService.getUserEvents(userId);
+    }
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/entity/Event.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/entity/Event.java
@@ -1,0 +1,20 @@
+package ru.yandex.practicum.filmorate.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@RequiredArgsConstructor
+public class Event {
+    @JsonProperty("eventId")
+    Long id;
+    Long userId;
+    EventType eventType;
+    EventOperation operation;
+    @JsonProperty("timestamp")
+    long epochMilli;
+    long entityId;
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/entity/EventOperation.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/entity/EventOperation.java
@@ -1,0 +1,11 @@
+package ru.yandex.practicum.filmorate.entity;
+
+public enum EventOperation {
+    REMOVE,
+    ADD,
+    UPDATE;
+
+    public static EventOperation get(final int ordinal) {
+        return EventOperation.values()[ordinal];
+    }
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/entity/EventType.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/entity/EventType.java
@@ -1,0 +1,11 @@
+package ru.yandex.practicum.filmorate.entity;
+
+public enum EventType {
+    LIKE,
+    REVIEW,
+    FRIEND;
+
+    public static EventType get(final int code) {
+        return EventType.values()[code];
+    }
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/repository/DbEventStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/repository/DbEventStorage.java
@@ -1,0 +1,39 @@
+package ru.yandex.practicum.filmorate.repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import ru.yandex.practicum.filmorate.entity.Event;
+import ru.yandex.practicum.filmorate.repository.mapper.EventRowMapper;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class DbEventStorage implements EventStorage {
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public List<Event> getUserEvents(long userId) {
+        final String GET_EVENTS_BY_USER_ID_QUERY = """
+                SELECT *
+                FROM events
+                WHERE user_id = ?
+                """;
+        log.debug("Выполнение запроса для получения всех событий, связанных с пользователем '{}'", userId);
+
+        List<Event> foundEvents = jdbcTemplate.query(
+                GET_EVENTS_BY_USER_ID_QUERY,
+                    new EventRowMapper(),
+                    userId);
+        if (foundEvents.isEmpty()) {
+            log.info("Ещё нет событий, связанных с пользователем '{}'", userId);
+        } else {
+            log.info("У пользователя '{}' найдено '{}' событий", userId, foundEvents.size());
+        }
+
+        return foundEvents;
+    }
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/repository/DbUserStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/repository/DbUserStorage.java
@@ -165,7 +165,7 @@ public class DbUserStorage implements UserStorage {
     @Override
     public List<User> getUserFriends(long userId) {
         final String GET_FRIENDS_QUERY = """
-                SELECT u.user_id, u.email, u.login, u.username, u.birthday
+                SELECT u.*
                 FROM friendship f
                 JOIN users u ON f.friend_id = u.user_id
                 WHERE f.user_id = ?

--- a/src/main/java/ru/yandex/practicum/filmorate/repository/EventLogger.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/repository/EventLogger.java
@@ -1,0 +1,8 @@
+package ru.yandex.practicum.filmorate.repository;
+
+import ru.yandex.practicum.filmorate.entity.EventOperation;
+import ru.yandex.practicum.filmorate.entity.EventType;
+
+public interface EventLogger {
+    void logEvent(long userId, EventType type, EventOperation operation, long entityId);
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/repository/EventStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/repository/EventStorage.java
@@ -1,0 +1,9 @@
+package ru.yandex.practicum.filmorate.repository;
+
+import ru.yandex.practicum.filmorate.entity.Event;
+
+import java.util.List;
+
+public interface EventStorage {
+    List<Event> getUserEvents(long eventId);
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/repository/mapper/EventRowMapper.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/repository/mapper/EventRowMapper.java
@@ -1,0 +1,32 @@
+package ru.yandex.practicum.filmorate.repository.mapper;
+
+import org.springframework.jdbc.core.RowMapper;
+import ru.yandex.practicum.filmorate.entity.Event;
+import ru.yandex.practicum.filmorate.entity.EventOperation;
+import ru.yandex.practicum.filmorate.entity.EventType;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class EventRowMapper implements RowMapper<Event> {
+    @Override
+    public Event mapRow(ResultSet rs, int rowNum) throws SQLException {
+        EventOperation eventOperation = EventOperation.get(rs.getInt("operation_id"));
+        EventType eventType = EventType.get(rs.getInt("type_id"));
+        return Event.builder()
+                .id(rs.getLong("id"))
+                .userId(rs.getLong("user_id"))
+                .epochMilli(rs.getLong("event_timestamp"))
+                .eventType(eventType)
+                .operation(eventOperation)
+                .entityId(rs.getLong("entity_id"))
+                .build();
+    }
+
+//    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+//    user_id BIGINT NOT NULL REFERENCES users (user_id) ON DELETE CASCADE,
+//    type_id TINYINT NOT NULL,
+//    operation_id TINYINT NOT NULL,
+//    entity_id BIGINT NOT NULL,
+//    event_timestamp BIGINT NOT NULL
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/repository/util/DataBaseEventLogger.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/repository/util/DataBaseEventLogger.java
@@ -1,0 +1,34 @@
+package ru.yandex.practicum.filmorate.repository.util;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import ru.yandex.practicum.filmorate.entity.EventOperation;
+import ru.yandex.practicum.filmorate.entity.EventType;
+import ru.yandex.practicum.filmorate.repository.EventLogger;
+
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Component
+@Slf4j
+public class DataBaseEventLogger implements EventLogger {
+    private final JdbcTemplate jdbcTemplate;
+
+    // Статический метод для логирования событий
+    public void logEvent(long userId, EventType type, EventOperation operation, long entityId) {
+        final int typeId = type.ordinal();
+        final int operationId = operation.ordinal();
+        final long eventTimestamp = System.currentTimeMillis();
+
+        final String LOG_EVENT_QUERY = """
+        INSERT INTO events (user_id, type_id, operation_id, entity_id, event_timestamp)
+        VALUES (?, ?, ?, ?, ?)
+        """;
+        jdbcTemplate.update(LOG_EVENT_QUERY, userId, typeId, operationId, entityId, eventTimestamp);
+        log.debug("Зарегестрировано новая операция '{}' над '{}' от пользователя с id = '{}'. Id субъекта = '{}'",
+                operation, type, userId, entityId);
+    }
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/service/DirectorService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/DirectorService.java
@@ -10,7 +10,7 @@ import ru.yandex.practicum.filmorate.entity.Director;
 import ru.yandex.practicum.filmorate.entity.Marker;
 import ru.yandex.practicum.filmorate.exception.NotFoundException;
 import ru.yandex.practicum.filmorate.repository.DirectorStorage;
-import ru.yandex.practicum.filmorate.service.util.DirectorValidator;
+import ru.yandex.practicum.filmorate.service.validators.DirectorValidator;
 
 import java.util.List;
 

--- a/src/main/java/ru/yandex/practicum/filmorate/service/EventService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/EventService.java
@@ -1,0 +1,24 @@
+package ru.yandex.practicum.filmorate.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import ru.yandex.practicum.filmorate.entity.Event;
+import ru.yandex.practicum.filmorate.repository.EventStorage;
+import ru.yandex.practicum.filmorate.service.validators.UserValidator;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EventService {
+    private final EventStorage eventStorage;
+    private final UserValidator userValidator;
+
+    public List<Event> getUserEvents(long userId) {
+        userValidator.checkUserOnExist(userId);
+
+        return eventStorage.getUserEvents(userId);
+    }
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmCrudService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmCrudService.java
@@ -7,9 +7,9 @@ import ru.yandex.practicum.filmorate.exception.InvalidDataRequestException;
 import ru.yandex.practicum.filmorate.exception.NotFoundException;
 import ru.yandex.practicum.filmorate.entity.Film;
 import ru.yandex.practicum.filmorate.repository.FilmStorage;
-import ru.yandex.practicum.filmorate.service.util.DirectorValidator;
-import ru.yandex.practicum.filmorate.service.util.FilmValidator;
-import ru.yandex.practicum.filmorate.service.util.UserValidator;
+import ru.yandex.practicum.filmorate.service.validators.DirectorValidator;
+import ru.yandex.practicum.filmorate.service.validators.FilmValidator;
+import ru.yandex.practicum.filmorate.service.validators.UserValidator;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmLikeService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmLikeService.java
@@ -4,11 +4,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import ru.yandex.practicum.filmorate.entity.Film;
+import ru.yandex.practicum.filmorate.repository.EventLogger;
 import ru.yandex.practicum.filmorate.repository.FilmStorage;
-import ru.yandex.practicum.filmorate.service.util.FilmValidator;
-import ru.yandex.practicum.filmorate.service.util.UserValidator;
+import ru.yandex.practicum.filmorate.service.validators.FilmValidator;
+import ru.yandex.practicum.filmorate.service.validators.UserValidator;
 
 import java.util.*;
+
+import static ru.yandex.practicum.filmorate.entity.EventOperation.ADD;
+import static ru.yandex.practicum.filmorate.entity.EventOperation.REMOVE;
+import static ru.yandex.practicum.filmorate.entity.EventType.LIKE;
 
 @Service
 @Slf4j
@@ -17,6 +22,7 @@ public class FilmLikeService {
     private final FilmStorage filmStorage;
     private final FilmValidator filmValidator;
     private final UserValidator userValidator;
+    private final EventLogger eventLogger;
 
     public void addLikeToFilm(long filmId, long userId) {
         log.info("(NEW) Получен запрос от пользователя на добавление лайка к фильму. userId='{}',filmId='{}'",
@@ -28,6 +34,7 @@ public class FilmLikeService {
         filmValidator.checkIsUserAlreadyLikedFilm(filmId, userId);
 
         filmStorage.saveLikeToFilm(filmId, userId);
+        eventLogger.logEvent(userId, LIKE, ADD, filmId);
     }
 
     public void removeLikeFromFilm(long filmId, long userId) {
@@ -37,6 +44,7 @@ public class FilmLikeService {
         userValidator.checkUserOnExist(userId);
 
         filmStorage.deleteLikeFromFilm(filmId, userId);
+        eventLogger.logEvent(userId, LIKE, REMOVE, filmId);
     }
 
     public Collection<Film> getMostLikedFilms(Integer count, Integer genreId, Integer year) {

--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmReviewService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmReviewService.java
@@ -7,19 +7,25 @@ import org.springframework.stereotype.Service;
 import ru.yandex.practicum.filmorate.entity.Review;
 import ru.yandex.practicum.filmorate.exception.InvalidDataRequestException;
 import ru.yandex.practicum.filmorate.exception.NotFoundException;
+import ru.yandex.practicum.filmorate.repository.EventLogger;
 import ru.yandex.practicum.filmorate.repository.ReviewStorage;
-import ru.yandex.practicum.filmorate.service.util.FilmValidator;
-import ru.yandex.practicum.filmorate.service.util.ReviewValidator;
-import ru.yandex.practicum.filmorate.service.util.UserValidator;
+import ru.yandex.practicum.filmorate.service.validators.FilmValidator;
+import ru.yandex.practicum.filmorate.service.validators.ReviewValidator;
+import ru.yandex.practicum.filmorate.service.validators.UserValidator;
 
 import java.util.List;
 import java.util.Optional;
+
+import static ru.yandex.practicum.filmorate.entity.EventOperation.*;
+import static ru.yandex.practicum.filmorate.entity.EventType.*;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class FilmReviewService {
     private final ReviewStorage reviewStorage;
+    private final EventLogger eventLogger;
+
     private final UserValidator userValidator;
     private final FilmValidator filmValidator;
     private final ReviewValidator reviewValidator;
@@ -28,16 +34,25 @@ public class FilmReviewService {
         userValidator.checkUserOnExist(review.getUserId());
         filmValidator.checkFilmOnExist(review.getFilmId());
         log.info("Добавление нового отзыва к фильму с id {}", review.getFilmId());
-        return reviewStorage.addReview(review);
+        Review savedReview = reviewStorage.addReview(review);
+        eventLogger.logEvent(savedReview.getUserId(), REVIEW, ADD, savedReview.getReviewId());
+        return savedReview;
     }
 
     public void updateReview(Review review) {
         reviewValidator.checkReviewOnExistence(review.getReviewId());
         reviewStorage.updateReview(review);
+        long userId = review.getUserId();
+        long entityId = review.getReviewId();
+        eventLogger.logEvent(userId, REVIEW, UPDATE, entityId);
     }
 
     public void deleteReview(long id) {
         log.info("Удаление отзыва с ID {}", id);
+        Review reviewForDelete = getReview(id);
+        long userId = reviewForDelete.getUserId();
+        long eventId = reviewForDelete.getReviewId();
+        eventLogger.logEvent(userId, REVIEW, REMOVE, eventId);
         reviewStorage.removeReview(id);
     }
 
@@ -62,9 +77,11 @@ public class FilmReviewService {
 
     public void addReviewLikeDislike(long reviewId, long userId, int likeStatus) {
         reviewStorage.addLikeDislike(reviewId, userId, likeStatus);
+        eventLogger.logEvent(userId, REVIEW, UPDATE, reviewId);
     }
 
     public void deleteReviewLikeDislike(long reviewId, long userId) {
         reviewStorage.removeLikeDislike(reviewId, userId);
+        eventLogger.logEvent(userId, REVIEW, UPDATE, reviewId);
     }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/service/UserCrudService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/UserCrudService.java
@@ -8,7 +8,7 @@ import ru.yandex.practicum.filmorate.entity.User;
 import ru.yandex.practicum.filmorate.entity.Marker;
 import ru.yandex.practicum.filmorate.exception.NotFoundException;
 import ru.yandex.practicum.filmorate.repository.UserStorage;
-import ru.yandex.practicum.filmorate.service.util.UserValidator;
+import ru.yandex.practicum.filmorate.service.validators.UserValidator;
 
 import java.util.Collection;
 

--- a/src/main/java/ru/yandex/practicum/filmorate/service/UserFriendsService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/UserFriendsService.java
@@ -3,9 +3,12 @@ package ru.yandex.practicum.filmorate.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import static ru.yandex.practicum.filmorate.entity.EventOperation.*;
+import static ru.yandex.practicum.filmorate.entity.EventType.*;
 import ru.yandex.practicum.filmorate.entity.User;
+import ru.yandex.practicum.filmorate.repository.EventLogger;
 import ru.yandex.practicum.filmorate.repository.UserStorage;
-import ru.yandex.practicum.filmorate.service.util.UserValidator;
+import ru.yandex.practicum.filmorate.service.validators.UserValidator;
 
 import java.util.List;
 
@@ -14,6 +17,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class UserFriendsService {
     private final UserStorage userStorage;
+    private final EventLogger eventLogger;
+
     private final UserValidator userValidator;
 
     public void addFriend(long userId, long friendId) {
@@ -23,6 +28,7 @@ public class UserFriendsService {
         userValidator.checkUserOnExist(friendId);
 
         userStorage.saveFriendToUser(userId, friendId);
+        eventLogger.logEvent(userId, FRIEND, ADD, friendId);
     }
 
     public void removeFriend(long userId, long friendId) {
@@ -33,6 +39,7 @@ public class UserFriendsService {
         userValidator.checkUserOnExist(friendId);
 
         userStorage.removeFriend(userId, friendId);
+        eventLogger.logEvent(userId, FRIEND, REMOVE, friendId);
     }
 
     public List<User> getUserFriends(long userId) {

--- a/src/main/java/ru/yandex/practicum/filmorate/service/validators/DirectorValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/validators/DirectorValidator.java
@@ -1,4 +1,4 @@
-package ru.yandex.practicum.filmorate.service.util;
+package ru.yandex.practicum.filmorate.service.validators;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/ru/yandex/practicum/filmorate/service/validators/FilmValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/validators/FilmValidator.java
@@ -1,6 +1,6 @@
-package ru.yandex.practicum.filmorate.service.util;
+package ru.yandex.practicum.filmorate.service.validators;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.springframework.stereotype.Component;
@@ -14,12 +14,11 @@ import ru.yandex.practicum.filmorate.repository.FilmStorage;
 import java.util.List;
 import java.util.Set;
 
-@AllArgsConstructor
-@Slf4j
 @Component
+@RequiredArgsConstructor
+@Slf4j
 public class FilmValidator {
-    private FilmStorage filmRepo;
-
+    private final FilmStorage filmRepo;
 
     public void checkFilmMpaRatingOnExist(Mpa mpa) throws InvalidDataRequestException {
         if (mpa == null) {

--- a/src/main/java/ru/yandex/practicum/filmorate/service/validators/ReviewValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/validators/ReviewValidator.java
@@ -1,4 +1,4 @@
-package ru.yandex.practicum.filmorate.service.util;
+package ru.yandex.practicum.filmorate.service.validators;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/ru/yandex/practicum/filmorate/service/validators/UserValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/validators/UserValidator.java
@@ -1,4 +1,4 @@
-package ru.yandex.practicum.filmorate.service.util;
+package ru.yandex.practicum.filmorate.service.validators;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,4 +1,5 @@
-DROP TABLE IF EXISTS mpa, users, films, genres, directors, films_genres, users_films_like, friendship, reviews, reviews_likes, films_directors, friendship;
+DROP TABLE IF EXISTS mpa, users, films, genres, directors,films_genres, users_films_like, friendship,
+    reviews, reviews_likes, films_directors, friendship, events;
 
 -- Таблица mpa
 CREATE TABLE IF NOT EXISTS mpa (
@@ -77,4 +78,14 @@ CREATE TABLE IF NOT EXISTS reviews_likes (
     user_id BIGINT NOT NULL REFERENCES users (user_id) ON DELETE CASCADE,
     liked BIT,
     PRIMARY KEY (review_id, user_id)
+);
+
+-- При удалении пользователя стираются все связанные с ним события
+CREATE TABLE IF NOT EXISTS events (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users (user_id) ON DELETE CASCADE,
+    type_id INTEGER NOT NULL,
+    operation_id INTEGER NOT NULL,
+    entity_id BIGINT NOT NULL,
+    event_timestamp BIGINT NOT NULL
 );


### PR DESCRIPTION
Короткое пояснение:
eventType и operation хранятся в базе данных в виде айдишников, которые присваиваются автоматически через `.ordinal()` метод (дефолтный джавовский метод для `Enum`ов).
Соответственно за сериализацию событий в базу данных отвечает класс DataBaseEventLogger, за десериализацию в Event - `EventRowMapper`.
За десериализацию из айдишника в enum отвечают методы get в `EventOperation` и `EventType` (более подробно про это я обсуждал в последнем беседе library в ПАЧКЕ, можете почитать, если будет интересно